### PR TITLE
fix(website): update links to github repository

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -6,19 +6,19 @@ sidebar_position: 2
 
 ## Windows
 
--   Download [`Irasshaimase_Polytech-0.1.0-pc.zip`](https://github.com/shelepuginivan/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-pc.zip)
+-   Download [`Irasshaimase_Polytech-0.1.0-pc.zip`](https://github.com/Nikilireous/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-pc.zip)
 -   Extract the archive
 -   Run `Irasshaimase_Polytech.exe`
 
 ## Linux
 
--   Download [`Irasshaimase_Polytech-0.1.0-pc.zip`](https://github.com/shelepuginivan/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-pc.zip)
+-   Download [`Irasshaimase_Polytech-0.1.0-pc.zip`](https://github.com/Nikilireous/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-pc.zip)
 -   Extract the archive
 -   Run `Irasshaimase_Polytech.sh`
 
 ## macOS
 
--   Download [`Irasshaimase_Polytech-0.1.0-mac.zip`](https://github.com/shelepuginivan/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-mac.zip)
+-   Download [`Irasshaimase_Polytech-0.1.0-mac.zip`](https://github.com/Nikilireous/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-mac.zip)
 -   Extract the archive
 -   Launch the app
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -80,7 +80,7 @@ const config = {
                         position: 'right',
                     },
                     {
-                        href: 'https://github.com/shelepuginivan/irasshaimase-to-polytech',
+                        href: 'https://github.com/Nikilireous/irasshaimase-to-polytech',
                         label: 'GitHub',
                         position: 'right',
                     },
@@ -107,7 +107,7 @@ const config = {
                         items: [
                             {
                                 label: 'GitHub',
-                                href: 'https://github.com/shelepuginivan/irasshaimase-to-polytech',
+                                href: 'https://github.com/Nikilireous/irasshaimase-to-polytech',
                             },
                             {
                                 html: `

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/installation.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/installation.md
@@ -6,19 +6,19 @@ sidebar_position: 2
 
 ## Windows
 
--   Скачайте файл [`Irasshaimase_Polytech-0.1.0-pc.zip`](https://github.com/shelepuginivan/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-pc.zip)
+-   Скачайте файл [`Irasshaimase_Polytech-0.1.0-pc.zip`](https://github.com/Nikilireous/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-pc.zip)
 -   Распакуйте архив
 -   Запустите `Irasshaimase_Polytech.exe`
 
 ## Linux
 
--   Скачайте файл [`Irasshaimase_Polytech-0.1.0-pc.zip`](https://github.com/shelepuginivan/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-pc.zip)
+-   Скачайте файл [`Irasshaimase_Polytech-0.1.0-pc.zip`](https://github.com/Nikilireous/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-pc.zip)
 -   Распакуйте архив
 -   Запустите `Irasshaimase_Polytech.sh`
 
 ## macOS
 
--   Скачайте файл [`Irasshaimase_Polytech-0.1.0-mac.zip`](https://github.com/shelepuginivan/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-mac.zip)
+-   Скачайте файл [`Irasshaimase_Polytech-0.1.0-mac.zip`](https://github.com/Nikilireous/irasshaimase-to-polytech/releases/download/v0.1.0/Irasshaimase_Polytech-0.1.0-mac.zip)
 -   Распакуйте архив
 -   Запустите приложение
 

--- a/website/i18n/ru/docusaurus-theme-classic/footer.json
+++ b/website/i18n/ru/docusaurus-theme-classic/footer.json
@@ -13,7 +13,7 @@
     },
     "link.item.label.GitHub": {
         "message": "GitHub",
-        "description": "The label of footer link with label=GitHub linking to https://github.com/shelepuginivan/irasshaimase-to-polytech"
+        "description": "The label of footer link with label=GitHub linking to https://github.com/Nikilireous/irasshaimase-to-polytech"
     },
     "copyright": {
         "message": "Copyright © 2023 Pink Phantasm. Сделано с помощью Docusaurus.",


### PR DESCRIPTION
Updated the GitHub repository links that became inoperable due to the repository transfer